### PR TITLE
Modified CI to label built image with dynamic name

### DIFF
--- a/continuous-integration/dagger/src/index.ts
+++ b/continuous-integration/dagger/src/index.ts
@@ -35,13 +35,13 @@ class ContinuousIntegration {
           dockerfile: 'Dockerfile'
         }
       )
-      .withLabel(
-        'org.opencontainers.image.source',
-        'https://github.com/geobeyond/Arpav-PPCV'
-      )
     if (publishDockerImage) {
       const sanitizedName = this._sanitizeDockerImageName(publishDockerImage)
-      return await builtImage.publish(sanitizedName)
+      const labeledImage = builtImage.withLabel(
+        'org.opencontainers.image.source',
+        publishDockerImage.split(':')[0]
+      )
+      return await labeledImage.publish(sanitizedName)
     } else {
       return 'Done!'
     }


### PR DESCRIPTION
This PR makes the CI dagger module use a dynamically-provided name for the label that is to be applied to the built container.

The docker label is important for linking between a github project and its corresponding packages

---

- fixes #20 